### PR TITLE
Fix SPI display transfer limit & Pillow text method

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,7 +79,10 @@ def draw_overlay(image, lat, lon, heading):
 
     draw.text((5, 5), f"{lat:.5f}, {lon:.5f}", fill="red", font=font)
     label = f"N {int(heading)}°"
-    tw, th = draw.textsize(label, font=font)
+    # textsize was removed in Pillow 10; use textbbox to get width/height.
+    lbbox = draw.textbbox((0, 0), label, font=font)
+    tw = lbbox[2] - lbbox[0]
+    th = lbbox[3] - lbbox[1]
     draw.text((SCREEN_WIDTH - tw - 5, SCREEN_HEIGHT - th - 5), label, fill="red", font=font)
 
     return image

--- a/st7796.py
+++ b/st7796.py
@@ -85,6 +85,10 @@ class ST7796:
 
         GPIO.output(self.dc, GPIO.HIGH)
         GPIO.output(self.cs, GPIO.LOW)
-        self.spi.writebytes(pixelbytes)
+        # Many Raspberry Pi kernels limit SPI transfers to 4kB. Chunk
+        # the data so large frames don't exceed that limit.
+        CHUNK_SIZE = 4096
+        for i in range(0, len(pixelbytes), CHUNK_SIZE):
+            self.spi.writebytes(pixelbytes[i:i + CHUNK_SIZE])
         GPIO.output(self.cs, GPIO.HIGH)
 


### PR DESCRIPTION
## Summary
- chunk SPI writes to respect 4kB limit on many Raspberry Pi kernels
- replace deprecated `draw.textsize` usage with `textbbox`

## Testing
- `python3 -m py_compile main.py st7796.py test_map_display.py`

------
https://chatgpt.com/codex/tasks/task_e_684dfe88c2548331901a5e60a8dfcc39